### PR TITLE
feat: add `setup-componentize-go` action

### DIFF
--- a/.github/actions/setup-componentize-go/action.yml
+++ b/.github/actions/setup-componentize-go/action.yml
@@ -11,22 +11,35 @@ runs:
   using: 'composite'
   steps:
     - name: Cache componentize-go
+      id: cache
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
       with:
-        path: |
-          ${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}
+        path: ${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}
         key: componentize-go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
     - name: Download componentize-go
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        bin_name="componentize-go-${{ runner.os }}-${{ runner.arch }}"
+        case "${{ runner.os }}-${{ runner.arch }}" in
+          Linux-X64)     os="linux";   arch="amd64" ;;
+          Linux-ARM64)   os="linux";   arch="arm64" ;;
+          macOS-X64)     os="darwin";  arch="amd64" ;;
+          macOS-ARM64)   os="darwin";  arch="arm64" ;;
+          Windows-X64)   os="windows"; arch="amd64" ;;
+          *) echo "Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
+        esac
 
-        # Download release
-        curl -LO https://github.com/bytecodealliance/componentize-go/releases/download/${{ inputs.version }}/${bin_name}.tar.gz
-        tar -xvzf ${bin_name}.tar.gz
+        archive="componentize-go-${os}-${arch}.tar.gz"
+        curl -fsSL "https://github.com/bytecodealliance/componentize-go/releases/download/${{ inputs.version }}/${archive}" \
+          -o "${archive}"
+        tar -xzf "${archive}"
 
-        # Add to cache
         cache_dir="${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}"
         mkdir -p "${cache_dir}"
-        cp componentize-go "${cache_dir}"
-        chmod +x  "${cache_dir}/componentize-go"
+        cp componentize-go "${cache_dir}/"
+        chmod +x "${cache_dir}/componentize-go"
+
+    - name: Add componentize-go to PATH
+      shell: bash
+      run: echo "${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}" >> "$GITHUB_PATH"

--- a/.github/actions/setup-componentize-go/action.yml
+++ b/.github/actions/setup-componentize-go/action.yml
@@ -1,6 +1,5 @@
 name: 'setup-componentize-go'
 description: 'Setup componentize-go for your Github Actions workflow'
-author: 'James Stockton<james.stocktonj@gmail.com>'
 
 inputs:
   version:

--- a/.github/actions/setup-componentize-go/action.yml
+++ b/.github/actions/setup-componentize-go/action.yml
@@ -17,16 +17,15 @@ runs:
         path: ${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}
         key: componentize-go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
-    - name: Download componentize-go
-      if: steps.cache.outputs.cache-hit != 'true'
+    - name: Download componentize-go (Unix)
+      if: steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
       shell: bash
       run: |
         case "${{ runner.os }}-${{ runner.arch }}" in
-          Linux-X64)     os="linux";   arch="amd64" ;;
-          Linux-ARM64)   os="linux";   arch="arm64" ;;
-          macOS-X64)     os="darwin";  arch="amd64" ;;
-          macOS-ARM64)   os="darwin";  arch="arm64" ;;
-          Windows-X64)   os="windows"; arch="amd64" ;;
+          Linux-X64)   os="linux";  arch="amd64" ;;
+          Linux-ARM64) os="linux";  arch="arm64" ;;
+          macOS-X64)   os="darwin"; arch="amd64" ;;
+          macOS-ARM64) os="darwin"; arch="arm64" ;;
           *) echo "Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
         esac
 
@@ -39,6 +38,20 @@ runs:
         mkdir -p "${cache_dir}"
         cp componentize-go "${cache_dir}/"
         chmod +x "${cache_dir}/componentize-go"
+
+    - name: Download componentize-go (Windows)
+      if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $archive = "componentize-go-windows-amd64.zip"
+        Invoke-WebRequest `
+          -Uri "https://github.com/bytecodealliance/componentize-go/releases/download/${{ inputs.version }}/$archive" `
+          -OutFile $archive
+        Expand-Archive -Path $archive -DestinationPath .
+
+        $cache_dir = "${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}"
+        New-Item -ItemType Directory -Force -Path $cache_dir | Out-Null
+        Copy-Item componentize-go.exe "$cache_dir/"
 
     - name: Add componentize-go to PATH
       shell: bash

--- a/.github/actions/setup-componentize-go/action.yml
+++ b/.github/actions/setup-componentize-go/action.yml
@@ -1,0 +1,32 @@
+name: 'setup-componentize-go'
+description: 'Setup componentize-go for your Github Actions workflow'
+author: 'James Stockton<james.stocktonj@gmail.com>'
+
+inputs:
+  version:
+    required: false
+    description: 'version of componentize-go to setup'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache componentize-go
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+      with:
+        path: |
+          ${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}
+        key: componentize-go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+    - name: Download componentize-go
+      shell: bash
+      run: |
+        bin_name="componentize-go-${{ runner.os }}-${{ runner.arch }}"
+
+        # Download release
+        curl -LO https://github.com/bytecodealliance/componentize-go/releases/download/${{ inputs.version }}/${bin_name}.tar.gz
+        tar -xvzf ${bin_name}.tar.gz
+
+        # Add to cache
+        cache_dir="${{ runner.tool_cache }}/componentize-go/${{ inputs.version }}"
+        mkdir -p "${cache_dir}"
+        cp componentize-go "${cache_dir}"
+        chmod +x  "${cache_dir}/componentize-go"


### PR DESCRIPTION
# Description
- Add `setup-componentize-go` action as per #10
- Downloads and adds to `PATH` for all 5 supported platform types
- Caches downloads 

## Example Run
Example run can be found below with cache entries:
https://github.com/jamesstocktonj1/componentize-sdk/actions/runs/23924915603

<img width="1305" height="528" alt="Screenshot from 2026-04-02 23-46-47" src="https://github.com/user-attachments/assets/8de88558-28d4-497a-b7c1-4ba5824e838b" />
