### PR TITLE
bump version to v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-go"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ reqwest = { version = "0.13.1", features = ["blocking"] }
 tar = "0.4"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [workspace.lints.clippy]


### PR DESCRIPTION
Unlike the `v0.3.1` tag I just pushed, this leaves the Go wrapper pointing to the "canary" release rather than the `v0.3.1` release, since this PR targets the `main` branch.