### PR TITLE
chore: prep for release

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,6 +36,6 @@ jobs:
           go-version: 'stable'
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "43.0.0"
+          version: "44.0.1"
       - run: rustup update stable --no-self-update && rustup default stable
       - run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-go"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash",
 ]
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1098,9 +1098,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -1449,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "69830ccbbf41c55eb585991659fb70867ef628193af3a495f09a6956f7615e59"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.245.1"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da55e60097e8b37b475a0fa35c3420dd71d9eb7bd66109978ab55faf56a57efb"
+checksum = "bf6f124f965aeeec4ed97f7176a7bb2c862f550d098d488ff258db2867893894"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -2177,8 +2177,8 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.54.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=6a13b247#6a13b247f8ea44e3d7b2bc0b64a8e1553ba5bf31"
+version = "0.57.1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=95995ce0abdfec2609d44d04537fe5378c1349c0#95995ce0abdfec2609d44d04537fe5378c1349c0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2187,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-go"
-version = "0.54.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=6a13b247#6a13b247f8ea44e3d7b2bc0b64a8e1553ba5bf31"
+version = "0.57.1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=95995ce0abdfec2609d44d04537fe5378c1349c0#95995ce0abdfec2609d44d04537fe5378c1349c0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.245.1"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4894f10d2d5cbc17c77e91f86a1e48e191a788da4425293b55c98b44ba3fcac9"
+checksum = "d66a8d940b203e145ddd71f7790118f4ae17f240c670a3b80fe3c2373d7c0e57"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2219,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.245.1"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+checksum = "50840f2e2cf170d910858089d7dfb3e97c6f9a0d6ec7bff7f7cc28f5aeacc15f"
 dependencies = [
  "anyhow",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = ["./tests"]
 anyhow = "1.0.102"
 bzip2 = "0.6.1"
 once_cell = "1.21.3"
-reqwest = { version = "0.13.1", features = ["blocking"] }
-tar = "0.4"
+reqwest = { version = "0.13.3", features = ["blocking"] }
+tar = "0.4.46"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 
 [workspace.lints.clippy]
@@ -42,13 +42,12 @@ anyhow = { workspace = true }
 bzip2 = { workspace = true }
 reqwest = { workspace = true }
 tar = { workspace = true }
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.1.0"
-# TODO: Switch to release 0.55.0 when it's available:
-wit-bindgen-go = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "6a13b247" }
-wit-component = "0.245.1"
-wit-parser = "0.245.1"
+wit-bindgen-go = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "95995ce0abdfec2609d44d04537fe5378c1349c0" }
+wit-component = "0.249.0"
+wit-parser = "0.249.0"
 which = "8.0.2"
 dirs = "6.0.0"

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // Although `componentize-go` is written in Rust, we can use this wrapper to
 // make it available using e.g. `go install` and/or `go tool`.
 func main() {
-	release := "v0.3.3"
+	release := "v0.3.4"
 
 	directories := userdirs.ForApp(
 		"componentize-go",


### PR DESCRIPTION
Update dependencies in preparation for v0.3.4 release, including an upstream bugfix in wit-bindgen for the generated Go bindings.