### PR TITLE
chore: prep for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-go"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ reqwest = { version = "0.13.4", features = ["blocking"] }
 tar = "0.4.46"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 
 [workspace.lints.clippy]

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // Although `componentize-go` is written in Rust, we can use this wrapper to
 // make it available using e.g. `go install` and/or `go tool`.
 func main() {
-	release := "v0.3.4"
+	release := "v0.4.0"
 
 	directories := userdirs.ForApp(
 		"componentize-go",


### PR DESCRIPTION
This constitutes a minor change due to the addition of the `install-go` subcommand.